### PR TITLE
Fix attachments

### DIFF
--- a/pymailgun/client.py
+++ b/pymailgun/client.py
@@ -46,11 +46,12 @@ class Client(object):
         if bcc:
             data['bcc'] = bcc
 
-        if files and isinstance(files, list):
-            attached_files = []
+        attached_files = []
+        if files:
+            if not isinstance(files, list):
+                files = [files]
             for f in files:
-                attached_files.append(('attachment', open(f)))
-            return self.__request('post', self.domain, 'messages', data=data,
-                                  files=attached_files)
+                attached_files.append(('attachment', open(f, 'rb')))
 
-        return self.__request('post', self.domain, 'messages', data=data)
+        return self.__request('post', self.domain, 'messages', data=data,
+                              files=attached_files)


### PR DESCRIPTION
This PR fixes file attachments. It essentially opens the provided files in binary mode. Plus, it also merges the two `return` statements. 